### PR TITLE
Restore helper functionality

### DIFF
--- a/test/e2e/CancellationFlow.test.ts
+++ b/test/e2e/CancellationFlow.test.ts
@@ -1,0 +1,47 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { time } from "@nomicfoundation/hardhat-toolbox/network-helpers";
+import { deployFullPlatformFixture } from "../fixtures";
+import { createTestContest } from "../helpers/ContestHelper";
+import { ContestEscrow } from "../../typechain-types";
+
+/**
+ * Test contest cancellation and refund of ETH prize.
+ */
+describe("Contest E2E Cancellation", function () {
+  it("cancels contest and refunds creator", async function () {
+    const fixture = await loadFixture(deployFullPlatformFixture);
+    const { contestFactory, feeManager, creator1 } = fixture;
+
+    const now = await time.latest();
+    const startTime = BigInt(now + 3600);
+    const endTime = BigInt(now + 7200);
+    const totalPrize = ethers.parseEther("2");
+
+    const { escrow } = await createTestContest(
+      contestFactory,
+      feeManager,
+      creator1,
+      {
+        token: ethers.ZeroAddress,
+        totalPrize,
+        template: 0,
+        startTime,
+        endTime,
+        metadata: { title: "Cancellation", description: "" },
+      }
+    );
+
+    const before = await ethers.provider.getBalance(creator1.address);
+    const tx = await escrow.connect(creator1).cancel("E2E cancel");
+    const receipt = await tx.wait();
+    const gasUsed = receipt ? receipt.gasUsed * receipt.gasPrice : 0n;
+    const after = await ethers.provider.getBalance(creator1.address);
+
+    expect(after).to.equal(before + totalPrize - gasUsed);
+
+    const info = await escrow.getContestInfo();
+    expect(info.isCancelled).to.be.true;
+  });
+});

--- a/test/e2e/ContestFlow.test.ts
+++ b/test/e2e/ContestFlow.test.ts
@@ -1,0 +1,68 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { time } from "@nomicfoundation/hardhat-toolbox/network-helpers";
+import { deployFullPlatformFixture } from "../fixtures";
+import { createTestContest, endContest, verifyPrizeClaim } from "../helpers/ContestHelper";
+import { ContestEscrow } from "../../typechain-types";
+
+/**
+ * E2E tests covering full contest lifecycle using ETH prizes.
+ */
+describe("Contest E2E Flow", function () {
+  it("runs full lifecycle with ETH prize", async function () {
+    const fixture = await loadFixture(deployFullPlatformFixture);
+    const { contestFactory, feeManager, creator1, winner1, winner2, jury1 } = fixture;
+
+    const now = await time.latest();
+    const startTime = BigInt(now + 3600); // start in 1 hour
+    const endTime = BigInt(now + 7200);   // end in 2 hours
+    const totalPrize = ethers.parseEther("1");
+
+    const { contestId, escrow, escrowAddress } = await createTestContest(
+      contestFactory,
+      feeManager,
+      creator1,
+      {
+        token: ethers.ZeroAddress,
+        totalPrize,
+        template: 1,
+        startTime,
+        endTime,
+        jury: [jury1.address],
+        metadata: {
+          title: "E2E ETH Contest",
+          description: "Full flow"
+        }
+      }
+    );
+
+    expect(contestId).to.be.gt(BigInt(0));
+    expect(ethers.isAddress(escrowAddress)).to.be.true;
+
+    const initialBalance = await ethers.provider.getBalance(escrowAddress);
+    expect(initialBalance).to.equal(totalPrize);
+
+    // move time to contest start then end
+    await time.increaseTo(Number(startTime) + 5);
+    await endContest(escrow as ContestEscrow);
+
+    const winners = [winner1.address, winner2.address];
+    const places = [1, 2];
+    await expect(escrow.connect(jury1).declareWinners(winners, places)).to.emit(
+      escrow,
+      "WinnersDeclared"
+    );
+
+    // calculate expected prizes
+    const distribution = await escrow.getDistribution();
+    const prize1 = (totalPrize * BigInt(distribution[0].percentage)) / BigInt(10000);
+    const prize2 = (totalPrize * BigInt(distribution[1].percentage)) / BigInt(10000);
+
+    const actual1 = await verifyPrizeClaim(escrow as ContestEscrow, winner1, prize1);
+    expect(actual1).to.be.closeTo(prize1, BigInt(1e14));
+
+    const actual2 = await verifyPrizeClaim(escrow as ContestEscrow, winner2, prize2);
+    expect(actual2).to.be.closeTo(prize2, BigInt(1e14));
+  });
+});

--- a/test/e2e/TokenFlow.test.ts
+++ b/test/e2e/TokenFlow.test.ts
@@ -1,0 +1,71 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { time } from "@nomicfoundation/hardhat-toolbox/network-helpers";
+import { deployFullPlatformFixture } from "../fixtures";
+import { createTestContest, endContest } from "../helpers/ContestHelper";
+import { ContestEscrow, MockUSDC } from "../../typechain-types";
+
+/**
+ * Full lifecycle test for contest with ERC20 prizes.
+ */
+describe("Contest E2E Token Flow", function () {
+  it("runs lifecycle with USDC prize", async function () {
+    const fixture = await loadFixture(deployFullPlatformFixture);
+    const { contestFactory, feeManager, creator1, winner1, winner2, jury1, mockUSDC } = fixture;
+
+    const now = await time.latest();
+    const startTime = BigInt(now + 3600);
+    const endTime = BigInt(now + 7200);
+    const totalPrize = ethers.parseUnits("1000", 6);
+
+    const { contestId, escrow, escrowAddress } = await createTestContest(
+      contestFactory,
+      feeManager,
+      creator1,
+      {
+        token: await mockUSDC.getAddress(),
+        totalPrize,
+        template: 1,
+        startTime,
+        endTime,
+        jury: [jury1.address],
+        metadata: {
+          title: "E2E USDC Contest",
+          description: "Token flow",
+        },
+      }
+    );
+
+    expect(contestId).to.be.gt(BigInt(0));
+    expect(ethers.isAddress(escrowAddress)).to.be.true;
+
+    const token = mockUSDC as MockUSDC;
+    const escrowBalance = await token.balanceOf(escrowAddress);
+    expect(escrowBalance).to.equal(totalPrize);
+
+    await time.increaseTo(Number(startTime) + 5);
+    await endContest(escrow as ContestEscrow);
+
+    const winners = [winner1.address, winner2.address];
+    const places = [1, 2];
+    await expect(escrow.connect(jury1).declareWinners(winners, places)).to.emit(
+      escrow,
+      "WinnersDeclared"
+    );
+
+    const distribution = await escrow.getDistribution();
+    const prize1 = (totalPrize * BigInt(distribution[0].percentage)) / BigInt(10000);
+    const prize2 = (totalPrize * BigInt(distribution[1].percentage)) / BigInt(10000);
+
+    const before1 = await token.balanceOf(winner1.address);
+    await escrow.connect(winner1).claimPrize();
+    const after1 = await token.balanceOf(winner1.address);
+    expect(after1 - before1).to.equal(prize1);
+
+    const before2 = await token.balanceOf(winner2.address);
+    await escrow.connect(winner2).claimPrize();
+    const after2 = await token.balanceOf(winner2.address);
+    expect(after2 - before2).to.equal(prize2);
+  });
+});

--- a/test/helpers/ContestHelper.ts
+++ b/test/helpers/ContestHelper.ts
@@ -1,329 +1,658 @@
 import { ethers } from "hardhat";
 import { time } from "@nomicfoundation/hardhat-toolbox/network-helpers";
-import {
-    ContestFactory,
-    ContestEscrow,
-    NetworkFeeManager
+import { 
+    ContestFactory, 
+    ContestEscrow, 
+    NetworkFeeManager 
 } from "../../typechain-types";
-import { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
-import { ContractTransactionResponse } from "ethers";
+import { TEST_CONSTANTS, CONTEST_TEMPLATES } from "../fixtures";
+import { prepareERC20Token } from "./TokenHelper";
 
-/**
- * Опции для создания тестового конкурса
- */
 export interface CreateContestOptions {
-    /** Название конкурса (по умолчанию: 'Test Contest') */
-    name?: string;
-    /** Описание конкурса (по умолчанию: 'Test Description') */
-    description?: string;
-    /** Адрес токена для выплаты (по умолчанию: адрес нативной валюты 0x0) */
-    paymentToken?: string;
-    /** Сумма призового фонда (по умолчанию: 1 ETH) */
-    prizeAmount?: bigint;
-    /** Срок подачи заявок в секундах (по умолчанию: 7 дней) */
-    submissionDeadline?: number;
-    /** Срок голосования в секундах (по умолчанию: 3 дня) */
-    votingDeadline?: number;
-    /** Минимальное количество членов жюри (по умолчанию: 3) */
-    minJurors?: number;
-    /** Массив адресов членов жюри (по умолчанию: пустой массив) */
-    jurors?: string[];
-    /** Комиссия платформы в процентах (по умолчанию: от NetworkFeeManager) */
-    platformFee?: number;
-    /** Наличие нематериальных призов (по умолчанию: false) */
-    hasNonMonetaryPrizes?: boolean;
-    /** Уникальный ID конкурса (по умолчанию: генерируется автоматически) */
-    uniqueId?: number;
-    /** Произвольное распределение призового фонда */
-    customDistribution?: {
-        places: number[];
-        percentages: number[];
-        descriptions: string[];
+    token?: string;
+    totalPrize?: bigint;
+    template?: number;
+    startDelay?: number;
+    duration?: number;
+    startTime?: bigint;    // Добавляем возможность указать конкретное время начала
+    endTime?: bigint;      // Добавляем возможность указать конкретное время окончания
+    jury?: string[];
+    metadata?: {
+        title?: string;
+        description?: string;
     };
+    hasNonMonetaryPrizes?: boolean;
+    uniqueId?: number;
+    customDistribution?: Array<{
+        place: number;
+        percentage: number;
+        description: string;
+    }>;
 }
 
-/**
- * Создает тестовый конкурс с заданными параметрами
- * @param contestFactory - Фабрика конкурсов
- * @param feeManager - Менеджер комиссий
- * @param creator - Создатель конкурса (Signer)
- * @param options - Настройки конкурса
- * @returns Объект с информацией о созданном конкурсе
- */
 export async function createTestContest(
     contestFactory: ContestFactory,
     feeManager: NetworkFeeManager,
-    creator: SignerWithAddress,
+    creator: any,
     options: CreateContestOptions = {}
 ): Promise<{
     contestId: bigint;
     escrow: ContestEscrow;
     escrowAddress: string;
-    transaction: ContractTransactionResponse;
+    transaction: any;
+    receipt: NonNullable<Awaited<ReturnType<typeof ethers.ContractTransactionResponse.prototype.wait>>>;
 }> {
-    // Устанавливаем значения по умолчанию
-    const name = options.name || 'Test Contest';
-    const description = options.description || 'Test Description';
-    const paymentToken = options.paymentToken || ethers.ZeroAddress;
-    const prizeAmount = options.prizeAmount || ethers.parseEther('1.0');
-    // Используем время блокчейна вместо Date.now() для избежания ошибки 'Start time in past'
-    const now = Math.floor(Date.now() / 1000) + 60; // Добавляем 60 секунд для надежности
-    const submissionDeadline = options.submissionDeadline || now + 7 * 24 * 60 * 60;
-    const votingDeadline = options.votingDeadline || submissionDeadline + 3 * 24 * 60 * 60;
-    const jurors = options.jurors || [];
-    const uniqueId = options.uniqueId || Math.floor(Math.random() * 1000000);
-    const hasNonMonetaryPrizes = options.hasNonMonetaryPrizes || false;
-
-    // Настраиваем распределение призового фонда как массив структур
-    let distributionArray: Array<{
-        place: number;
-        percentage: number;
-        description: string;
-    }>;
-
-    if (options.customDistribution) {
-        const { places, percentages, descriptions } = options.customDistribution;
-        distributionArray = places.map((place, index) => ({
-            place: place,
-            percentage: percentages[index] || 0,
-            description: descriptions[index] || `Place ${place}`
-        }));
-    } else {
-        // Стандартное распределение: 60% за 1 место, 30% за 2 место, 10% за 3 место
-        distributionArray = [
-            { place: 1, percentage: 6000, description: 'First place' },   // 60% в базисных пунктах
-            { place: 2, percentage: 3000, description: 'Second place' },  // 30% в базисных пунктах  
-            { place: 3, percentage: 1000, description: 'Third place' }    // 10% в базисных пунктах
-        ];
+    // Проверяем, что функция lastId доступна
+    let hasLastIdFunction;
+    let initialLastId = BigInt(0);
+    try {
+        initialLastId = await contestFactory.lastId();
+        console.log(`Начальное значение lastId перед созданием конкурса: ${initialLastId}`);
+        hasLastIdFunction = true;
+    } catch (error) {
+        console.warn(`Функция lastId недоступна: ${error}`);
+        hasLastIdFunction = false;
     }
 
-    // Получаем текущее время блокчейна для более точного startTime
-    const blockNum = await ethers.provider.getBlockNumber();
-    const block = await ethers.provider.getBlock(blockNum);
-    const blockTime = block ? block.timestamp : Math.floor(Date.now() / 1000);
+    // Проверяем валидность токена, если это не ETH
+    if (options.token && options.token !== ethers.ZeroAddress) {
+        try {
+            const validator = await ethers.getContractAt("TokenValidator", await contestFactory.tokenValidator());
+            const isValidToken = await validator.isValidToken(options.token);
+            const isStablecoin = await validator.isStablecoin(options.token);
+            console.log(`🔍 Проверка валидации токена: isValidToken=${isValidToken}, isStablecoin=${isStablecoin}`);
 
-    // Параметры для создания конкурса согласно CreateContestParamsStruct
-    const params = {
-        token: paymentToken, // Передаем адрес токена напрямую
-        totalPrize: prizeAmount,
-        template: 4, // Используем CUSTOM template (enum PrizeTemplate.CUSTOM = 4)
-        customDistribution: distributionArray, // Массив PrizeDistributionStruct
-        jury: jurors,
-        startTime: blockTime + 120, // Добавляем 2 минуты к текущему времени блока
-        endTime: votingDeadline,
-        contestMetadata: JSON.stringify({ name, description, uniqueId }),
-        hasNonMonetaryPrizes: hasNonMonetaryPrizes
+            // Если токен не валиден, попробуем исправить
+            if (!isValidToken) {
+                console.log(`⚠️ Токен не прошёл валидацию, пробуем исправить...`);
+                const [owner] = await ethers.getSigners();
+                await validator.connect(owner).setTokenWhitelist(options.token, true, "Added for test");
+
+                // Проверяем еще раз whitelist после исправления
+                const isValidNow = await validator.isValidToken(options.token);
+                console.log(`🔄 После исправления whitelist: isValidToken=${isValidNow}`);
+            }
+
+            // Отдельно проверяем и настраиваем стейблкоин
+            if (!isStablecoin) {
+                console.log(`⚠️ Токен не определен как стейблкоин, пробуем исправить...`);
+                const [owner] = await ethers.getSigners();
+
+                // Получаем информацию о токене для логирования
+                const mockToken = await ethers.getContractAt("MockERC20", options.token);
+                const tokenSymbol = await mockToken.symbol();
+                console.log(`Проверка стейблкоина для токена: ${tokenSymbol}`);
+
+                // Прямая вставка в массив стейблкоинов (если есть метод updateStablecoins)
+                try {
+                    // Получаем текущий список стейблкоинов
+                    const stablecoins = await validator.stablecoins
+                        ? await validator.stablecoins(0).then(() => {
+                            let coins = [];
+                            let i = 0;
+                            return (async function getCoins() {
+                                try {
+                                    while (true) {
+                                        coins.push(await validator.stablecoins(i));
+                                        i++;
+                                    }
+                                } catch {
+                                    return coins;
+                                }
+                            })();
+                        })
+                        : [];
+
+                    // Добавляем новый стейблкоин в массив, если такого метода еще нет
+                    await validator.connect(owner).batchWhitelist(
+                        [options.token],
+                        [true],
+                        `Stablecoin ${tokenSymbol} for tests`
+                    );
+
+                    // Проверяем, есть ли метод для обновления стейблкоинов
+                    const code = await ethers.provider.getCode(await validator.getAddress());
+                    console.log(`Проверяем наличие метода для стейблкоинов...`);
+
+                    // Пробуем разные подходы для определения стейблкоина
+                    try {
+                        // Пытаемся установить токен как стейблкоин напрямую
+                        await validator.connect(owner).setTokenIsStablecoin?.(options.token, true);
+                        console.log(`✅ Токен установлен как стейблкоин через setTokenIsStablecoin`);
+                    } catch (e) {
+                        console.log(`Не удалось использовать setTokenIsStablecoin: ${e.message}`);
+
+                        try {
+                            // Пробуем обновить TokenInfo напрямую
+                            await validator.connect(owner).updateTokenInfo?.(options.token);
+                            console.log(`✅ Обновлена информация о токене через updateTokenInfo`);
+                        } catch (e2) {
+                            console.log(`Не удалось использовать updateTokenInfo: ${e2.message}`);
+                        }
+                    }
+                } catch (updateErr) {
+                    console.log(`⚠️ Не удалось обновить стейблкоины: ${updateErr}`);
+                }
+
+                // Проверяем еще раз после исправления
+                const isStablecoinNow = await validator.isStablecoin(options.token);
+                console.log(`🔄 После исправления стейблкоина: isStablecoin=${isStablecoinNow}`);
+            }
+        } catch (error) {
+            console.warn(`⚠️ Ошибка при проверке валидности токена: ${error}`);
+        }
+    }
+    console.log("Начало создания тестового конкурса с параметрами:", JSON.stringify(options, (_, value) => 
+        typeof value === 'bigint' ? value.toString() : value
+    ));
+    const now = await time.latest();
+    const uniqueId = options.uniqueId || Math.floor(Math.random() * 1000000);
+    
+    // Используем startTime и endTime из параметров, если они указаны
+    const startTime = options.startTime ? options.startTime : 
+        BigInt(now + (options.startDelay || TEST_CONSTANTS.DEFAULT_START_DELAY) + (uniqueId % 100));
+
+    const endTime = options.endTime ? options.endTime :
+        BigInt(now + (options.startDelay || TEST_CONSTANTS.DEFAULT_START_DELAY) + 
+        (options.duration || TEST_CONSTANTS.DEFAULT_DURATION));
+
+    const config = {
+        token: options.token || ethers.ZeroAddress,
+        totalPrize: options.totalPrize || TEST_CONSTANTS.MEDIUM_PRIZE,
+        template: options.template !== undefined ? options.template : CONTEST_TEMPLATES.TOP_2,
+        jury: options.jury || [],
+        hasNonMonetaryPrizes: options.hasNonMonetaryPrizes || false,
+        customDistribution: options.customDistribution || []
     };
 
-    // Создаем конкурс
-    let tx: ContractTransactionResponse;
-    try {
-        // Проверяем параметры перед созданием конкурса
-        if (!contestFactory || !creator) {
-            throw new Error("Некорректные параметры для создания конкурса");
-        }
+    const contestParams = {
+        token: config.token,
+        totalPrize: config.totalPrize,
+        template: config.template,
+        customDistribution: config.customDistribution.length > 0 ? config.customDistribution : [],
+        jury: config.jury,
+        startTime: startTime,
+        endTime: endTime,
+        contestMetadata: JSON.stringify({
+            title: options.metadata?.title || `Test Contest #${uniqueId}`,
+            description: options.metadata?.description || `Test contest for automated testing (ID: ${uniqueId})`
+        }),
+        hasNonMonetaryPrizes: config.hasNonMonetaryPrizes
+    };
 
-        // Проверяем баланс перед созданием конкурса
-        if (paymentToken === ethers.ZeroAddress) {
-            // Получаем текущую комиссию сети
-            const networkFee = await feeManager.networkFees(31337); // hardhat chainId
-            console.log(`Комиссия сети: ${networkFee} базисных пунктов`);
+    let createTx;
+    
+    if (config.token === ethers.ZeroAddress) {
+        const platformFee = await feeManager.calculateFee(31337, config.totalPrize);
+        const totalRequired = config.totalPrize + platformFee;
+        
+        console.log(`Создание конкурса с ETH: приз=${ethers.formatEther(config.totalPrize)}, комиссия=${ethers.formatEther(platformFee)}, всего=${ethers.formatEther(totalRequired)}`);
 
-            // Рассчитываем комиссию (fee = prize * feeRate / 10000)
-            const platformFee = prizeAmount * BigInt(networkFee) / 10000n;
-            const totalRequired = prizeAmount + platformFee;
-
-            console.log(`Сумма приза: ${ethers.formatEther(prizeAmount)} ETH`);
-            console.log(`Комиссия платформы: ${ethers.formatEther(platformFee)} ETH`);
-            console.log(`Всего требуется: ${ethers.formatEther(totalRequired)} ETH`);
-
-            // Проверка баланса ETH
-            const balance = await ethers.provider.getBalance(creator.address);
-            console.log(`Баланс ETH создателя: ${ethers.formatEther(balance)}`);
-
-            if (balance < totalRequired) {
-                throw new Error(`Недостаточно ETH для создания конкурса. Баланс: ${ethers.formatEther(balance)}, требуется: ${ethers.formatEther(totalRequired)}`);
-            }
-
-            // Если конкурс с ETH, добавляем value при отправке транзакции с учетом комиссии
-            tx = await contestFactory.connect(creator).createContest(params, { value: totalRequired });
-        } else {
-            // Если конкурс с токеном ERC20
-            // Проверка существования токена
-            if (!paymentToken) {
-                throw new Error("Адрес токена не определен");
-            }
-
-            // Проверяем одобрение токена
-            const tokenContract = await ethers.getContractAt("IERC20", paymentToken);
-            const allowance = await tokenContract.allowance(creator.address, await contestFactory.getAddress());
-
-            if (allowance < prizeAmount) {
-                await tokenContract.connect(creator).approve(
-                    await contestFactory.getAddress(),
-                    prizeAmount * 2n
-                );
-            }
-
-            tx = await contestFactory.connect(creator).createContest(params);
-        }
-    } catch (error) {
-        console.error(`Ошибка при создании конкурса: ${error}`);
-        throw error;
-    }
-
-    // Ждем выполнения транзакции и получаем receipt
-    const receipt = await tx.wait();
-    if (!receipt) {
-        throw new Error('Transaction receipt is null');
-    }
-
-    // Ищем событие ContestCreated
-    const contestCreatedEvent = receipt.logs.find(log => {
         try {
-            const parsed = contestFactory.interface.parseLog({
-                topics: log.topics as string[],
-                data: log.data
+            createTx = await contestFactory.connect(creator).createContest(contestParams, {
+                value: totalRequired,
+                gasLimit: 5000000  // Увеличиваем лимит газа
             });
-            return parsed?.name === 'ContestCreated';
-        } catch (e) {
-            return false;
+        } catch (error) {
+            console.error(`Ошибка при создании конкурса с ETH: ${error}`);
+            throw error;
         }
-    });
+    } else {
+        const token = await ethers.getContractAt("MockERC20", config.token);
+        const platformFee = await feeManager.calculateFee(31337, config.totalPrize);
+        const totalRequired = config.totalPrize + platformFee;
 
-    if (!contestCreatedEvent) {
-        throw new Error('Contest creation failed: ContestCreated event not found');
+        const tokenValidator = await ethers.getContractAt("TokenValidator", 
+            await contestFactory.tokenValidator()
+        );
+        
+        // Добавляем токен в белый список перед созданием конкурса
+        try {
+            const isWhitelisted = await tokenValidator.whitelistedTokens(config.token);
+            if (!isWhitelisted) {
+                // Используем owner, а не creator для добавления в whitelist
+                const [owner] = await ethers.getSigners();
+                const addToWhitelistTx = await tokenValidator.connect(owner).setTokenWhitelist(
+                    config.token,
+                    true,
+                    "Test whitelist for mock token"
+                );
+                await addToWhitelistTx.wait();
+                console.log(`   ✅ Добавлен в whitelist с использованием owner`);
+            } else {
+                console.log(`   ℹ️ Токен уже в whitelist`);
+            }
+
+            // Дополнительно проверяем и устанавливаем флаг стейблкоина если нужно
+            try {
+                // В TypeScript не видит метод isStablecoin, но он существует в контракте
+                // @ts-ignore: Property 'isStablecoin' does not exist on type 'TokenValidator'
+                // Используем метод isStablecoin из интерфейса ITokenValidator
+                const isStablecoin = await tokenValidator.isStablecoin(config.token);
+                if (!isStablecoin) {
+                    const [owner] = await ethers.getSigners();
+
+                    // Получаем символ токена через getContractAt вместо IERC20Metadata
+                    const mockToken = await ethers.getContractAt("MockERC20", config.token);
+                    const tokenSymbol = await mockToken.symbol();
+
+                    // Проверяем, является ли токен потенциальным стейблкоином по имени
+                    const stablecoinSymbols = ['USDT', 'USDC', 'BUSD', 'DAI'];
+                    const isStablecoinSymbol = stablecoinSymbols.includes(tokenSymbol) || 
+                                             tokenSymbol.startsWith('USD');
+
+                    if (isStablecoinSymbol) {
+                        // Пробуем разные методы для установки стейблкоина
+                        try {
+                            // Пробуем получить тип контракта для определения доступных методов
+                            // @ts-ignore: Игнорируем ошибку, так как метод может быть доступен в реализации
+                            const isMock = await tokenValidator.isMockTokenValidator?.().catch(() => false);
+
+                            if (isMock) {
+                                // Если это мок, используем метод setupToken
+                                const mockValidator = await ethers.getContractAt("MockTokenValidator", await tokenValidator.getAddress());
+                                await mockValidator.connect(owner).setupToken(
+                                    config.token,
+                                    await mockToken.name(),
+                                    tokenSymbol,
+                                    await mockToken.decimals(),
+                                    ethers.parseUnits("1", 8), // $1 с 8 десятичными
+                                    true, // isStable = true
+                                    false  // isWrappedNative = false
+                                );
+                            } else {
+                                // Для реального валидатора
+                                await tokenValidator.connect(owner).setTokenIsStablecoin(config.token, true);
+                            }
+                            console.log(`   ✅ Токен установлен как стейблкоин`);
+                        } catch (error) {
+                            console.log(`   ⚠️ Ошибка при установке стейблкоина: ${error}`);
+
+                            // Добавляем в массив стейблкоинов напрямую, если это возможно
+                            try {
+                                const stablecoinsField = await tokenValidator.getStablecoins().catch(() => []);
+                                if (Array.isArray(stablecoinsField)) {
+                                    // @ts-ignore: Игнорируем ошибку, так как метод может быть доступен в реализации
+                                    await tokenValidator.connect(owner).updateStablecoins?.([
+                                        ...stablecoinsField, config.token
+                                    ]);
+                                    console.log(`   ✅ Токен добавлен в массив стейблкоинов`);
+                                }
+                            } catch (updateError) {
+                                console.log(`   ⚠️ Невозможно обновить список стейблкоинов: ${updateError}`);
+                            }
+                        }
+                    } else {
+                        console.log(`   ℹ️ Токен ${tokenSymbol} не определен как стейблкоин по символу`);
+                    }
+                } else {
+                    console.log(`   ✅ Токен уже является стейблкоином`);
+                }
+            } catch (stablecoinError) {
+                console.log(`   ⚠️ Не удалось установить флаг стейблкоина: ${stablecoinError}`);
+            }
+        } catch (error) {
+            console.log(`   ⚠️ Не удалось добавить токен в whitelist: ${error}`);
+        }
+
+        await prepareERC20Token(
+            token,
+            tokenValidator,
+            creator,
+            totalRequired,
+            await contestFactory.getAddress()
+        );
+        
+        console.log(`Создание конкурса с токеном ${config.token}: приз=${config.totalPrize}, комиссия=${platformFee}, всего=${totalRequired}`);
+
+        // Проверяем, нужно ли передавать totalRequired при вызове createContest
+        // Если токен стейблкоин, то в смарт-контракте логика комиссии отличается
+        const isStablecoin = await tokenValidator.isStablecoin(config.token);
+        console.log(`Токен ${await token.symbol()} является стейблкоином: ${isStablecoin}`);
+
+        // Получаем и проверяем важные параметры токена
+        const tokenDecimals = await token.decimals();
+        const tokenName = await token.name();
+        const tokenSymbol = await token.symbol();
+        console.log(`Параметры токена: name=${tokenName}, symbol=${tokenSymbol}, decimals=${tokenDecimals}`);
+
+        try {
+            // Сначала пробуем оценить газ для операции
+            try {
+                const gasEstimate = await contestFactory.connect(creator).createContest.estimateGas(contestParams);
+                console.log(`Оценка газа для createContest: ${gasEstimate} (добавим 30% запаса)`);                
+                const gasLimit = Math.ceil(Number(gasEstimate) * 1.3); // Добавляем 30% запаса
+
+                createTx = await contestFactory.connect(creator).createContest(contestParams, {
+                    gasLimit: gasLimit
+                });
+                console.log(`Транзакция отправлена с gasLimit: ${gasLimit}`);
+            } catch (gasError) {
+                console.warn(`Не удалось оценить газ: ${gasError}, используем фиксированное значение`);                
+
+                // Если не удалось оценить газ, используем увеличенный лимит
+                const gasLimit = 30000000; // Увеличиваем лимит газа еще больше
+                console.log(`Используем фиксированный gasLimit: ${gasLimit}`);
+
+                createTx = await contestFactory.connect(creator).createContest(contestParams, {
+                    gasLimit: gasLimit
+                });
+            }
+        } catch (error) {
+            console.error(`Ошибка при создании конкурса с токеном: ${error}`);
+
+            // Расширенная отладочная информация
+            const err = error as any; // Явное приведение к any для доступа к свойствам
+
+            if (err && typeof err === 'object') {
+                if ('message' in err) {
+                    console.error(`Сообщение ошибки: ${err.message}`);
+                }
+
+                if ('code' in err) {
+                    console.error(`Код ошибки: ${err.code}`);
+                }
+
+                if ('transaction' in err) {
+                    console.error(`Данные транзакции: ${JSON.stringify(err.transaction)}`);
+                }
+
+                if ('receipt' in err) {
+                    console.error(`Чек транзакции: ${JSON.stringify(err.receipt)}`);
+                }
+            }
+
+            throw error;
+        }
     }
 
-    // Парсим данные из события
-    const parsedEvent = contestFactory.interface.parseLog({
-        topics: contestCreatedEvent.topics as string[],
-        data: contestCreatedEvent.data
-    });
+    const receipt = await createTx.wait();
+    if (!receipt) throw new Error("Transaction receipt is null");
+    if (!receipt.logs) throw new Error("Transaction receipt logs are missing");
 
-    if (!parsedEvent) {
-        throw new Error('Failed to parse ContestCreated event');
+    console.log(`Получено ${receipt.logs.length} логов из транзакции`);
+
+    let contestId: bigint | null = null;
+    let escrowAddress: string | null = null;
+
+    // Более надежный способ поиска события по topicHash
+    let eventTopicHash;
+    try {
+        const eventDef = contestFactory.interface.getEvent("ContestCreated");
+        eventTopicHash = eventDef?.topicHash;
+        console.log(`Найдено определение события ContestCreated с topicHash: ${eventTopicHash}`);
+    } catch (error) {
+        console.error(`Ошибка при получении topicHash для ContestCreated: ${error}`);
     }
 
-    const contestId = parsedEvent.args.contestId as bigint;
-    const escrowAddress = parsedEvent.args.escrow as string;
+    // Генерируем различные варианты хешей для события
+    const possibleSignatures = [
+        "ContestCreated(uint256,address,address,uint256,uint256)",
+        "ContestCreated(uint256,address,address,address,uint256,uint256)",
+        "ContestCreated(uint256,address,address)"
+    ];
 
-    // Подключаемся к контракту эскроу
-    const escrow = await ethers.getContractAt('ContestEscrow', escrowAddress) as ContestEscrow;
+    const signatureHashes = [];
+    for (const sig of possibleSignatures) {
+        try {
+            const hash = ethers.id(sig);
+            signatureHashes.push(hash);
+            console.log(`Хеш для сигнатуры ${sig}: ${hash}`);
+        } catch (err) {
+            console.error(`Не удалось сгенерировать хеш для ${sig}: ${err}`);
+        }
+    }
+
+    // Выводим первые несколько topicHash для отладки
+    if (receipt.logs.length > 0) {
+        console.log(`Первые топики логов:`);
+        for (let i = 0; i < Math.min(5, receipt.logs.length); i++) {
+            if (receipt.logs[i].topics.length > 0) {
+                console.log(`Log ${i}: ${receipt.logs[i].topics[0]}`);
+            }
+        }
+    }
+
+    let contestCreatedLog = null;
+
+    // Сначала пробуем найти через eventTopicHash
+    if (eventTopicHash) {
+        contestCreatedLog = receipt.logs.find(log => 
+            log.topics.length > 0 && log.topics[0] === eventTopicHash
+        );
+
+        if (contestCreatedLog) {
+            console.log(`Найден лог с основным хешем события: ${eventTopicHash}`);
+        }
+    }
+
+    // Если не нашли, пробуем через все возможные хеши
+    if (!contestCreatedLog) {
+        for (const hash of signatureHashes) {
+            const log = receipt.logs.find(log => 
+                log.topics.length > 0 && log.topics[0] === hash
+            );
+
+            if (log) {
+                contestCreatedLog = log;
+                console.log(`Найден лог с альтернативным хешем события: ${hash}`);
+                break;
+            }
+        }
+    }
+
+    if (contestCreatedLog) {
+        try {
+            const decodedEvent = contestFactory.interface.parseLog(contestCreatedLog);
+            if (decodedEvent && decodedEvent.args) {
+                    // Пробуем получить по именам
+                    contestId = decodedEvent.args.contestId;
+                    escrowAddress = decodedEvent.args.escrow;
+
+                    // Если не получилось, пробуем по индексам
+                    if (!contestId) {
+                        contestId = decodedEvent.args[0];
+                    }
+
+                    if (!escrowAddress) {
+                        // Пробуем разные индексы для escrowAddress
+                        for (let i = 1; i < 4; i++) {
+                            if (ethers.isAddress(decodedEvent.args[i])) {
+                                escrowAddress = decodedEvent.args[i];
+                                break;
+                            }
+                        }
+                    }
+
+                    console.log(`Найдено событие ContestCreated! ID: ${contestId}, Эскроу: ${escrowAddress}`);
+                }
+            } catch (error) {
+                console.log(`Ошибка при разборе события: ${error}`);
+
+                // Пробуем разобрать вручную
+                try {
+                    // Предполагаем, что первый параметр - contestId, а один из следующих - escrowAddress
+                    const data = contestCreatedLog.data;
+                    const topics = contestCreatedLog.topics;
+
+                    console.log(`Данные лога: data=${data}, topics=${topics.join(', ')}`);
+
+                    // Пробуем извлечь contestId из первого параметра в data (убираем 0x и берем первые 64 символа)
+                    if (data && data.length >= 66) {
+                        const idHex = '0x' + data.substring(2, 66);
+                        contestId = BigInt(idHex);
+                        console.log(`Извлечен contestId=${contestId} из data`);
+                    }
+
+                    // Пробуем найти адрес в data
+                    if (data && data.length >= 130) {
+                        const addrHex = '0x' + data.substring(26, 66); // 40 символов с отступом
+                        if (ethers.isAddress(addrHex)) {
+                            escrowAddress = addrHex;
+                            console.log(`Извлечен escrowAddress=${escrowAddress} из data`);
+                        }
+                    }
+                } catch (innerError) {
+                    console.error(`Ошибка при ручном разборе события: ${innerError}`);
+                }
+        }
+    } else {
+        // Если не нашли событие, проверяем все логи последовательно
+        console.log(`Проверка всех ${receipt.logs.length} логов на наличие ContestCreated...`);
+        for (const log of receipt.logs) {
+            try {
+                const parsed = contestFactory.interface.parseLog({
+                    topics: log.topics,
+                    data: log.data
+                });
+
+                if (parsed && parsed.name === "ContestCreated" && parsed.args) {
+                    contestId = parsed.args.contestId;
+                    escrowAddress = parsed.args.escrow;
+                    console.log(`Найдено событие ContestCreated! ID: ${contestId}, Эскроу: ${escrowAddress}`);
+                    break;
+                }
+            } catch (error) {
+                // Игнорируем ошибки парсинга
+                continue;
+            }
+        }
+    }
+
+    // Если не нашли событие, получаем информацию другим способом
+    if (contestId === null || !escrowAddress) {
+        console.log("Используем альтернативный метод получения информации о конкурсе...");
+
+        // Получаем lastId из ContestFactory, который должен быть равен только что созданному contestId
+        try {
+            contestId = await contestFactory.lastId();
+            console.log(`Получен contestId из lastId: ${contestId}`);
+
+            // Если contestId равен 0, это может означать, что транзакция не удалась или контракт не обновил счетчик
+            if (contestId === BigInt(0)) {
+                console.warn("Warning: lastId вернул 0, что может указывать на проблему с созданием конкурса");
+            }
+        } catch (error) {
+            console.error(`Ошибка при получении lastId: ${error}`);
+            // Устанавливаем contestId в 1 как запасной вариант, чтобы продолжить выполнение
+            contestId = BigInt(1);
+            console.log(`Используем запасной contestId: ${contestId}`);
+        }
+
+        try {
+            // Получаем информацию о конкурсе через getContestInfo
+            const contestInfo = await contestFactory.getContestInfo(Number(contestId));
+            if (contestInfo && contestInfo.escrowAddress) {
+                escrowAddress = contestInfo.escrowAddress;
+            }
+        } catch (error) {
+            console.log(`Ошибка при вызове getContestInfo: ${error}`);
+            try {
+                // Если getContestInfo не существует, получаем адрес эскроу напрямую из массива
+                escrowAddress = await contestFactory.escrows(Number(contestId) - 1);
+            } catch (nestedError) {
+                console.log(`Ошибка при доступе к escrows: ${nestedError}`);
+            }
+        }
+
+        if (!escrowAddress || escrowAddress === ethers.ZeroAddress) {
+            throw new Error(`Не удалось получить адрес эскроу для contestId ${contestId}`);
+        }
+    }
+
+    // Убедимся, что escrowAddress - это строка и имеет правильный формат
+    let escrowAddressStr = '';
+    try {
+        escrowAddressStr = escrowAddress.toString();
+        // Проверяем, что адрес начинается с 0x и имеет правильную длину
+        if (!escrowAddressStr.startsWith('0x')) {
+            escrowAddressStr = '0x' + escrowAddressStr;
+        }
+
+        // Убедимся, что длина адреса правильная (0x + 40 символов)
+        if (escrowAddressStr.length !== 42) {
+            console.warn(`Предупреждение: Возможно некорректный формат адреса: ${escrowAddressStr} (длина ${escrowAddressStr.length})`);
+        }
+
+        console.log(`Получение контракта ContestEscrow по адресу: ${escrowAddressStr}`);
+    } catch (error) {
+        console.error(`Ошибка при обработке адреса эскроу: ${error}`);
+        throw new Error(`Не удалось обработать адрес эскроу: ${error}`);
+    }
+
+    let escrow: ContestEscrow;
+    try {
+        escrow = await ethers.getContractAt("ContestEscrow", escrowAddressStr) as unknown as ContestEscrow;
+        // Проверяем, что контракт действителен, пытаясь вызвать какой-то метод
+        await escrow.getAddress();
+        console.log(`Контракт эскроу успешно получен и проверен`);
+    } catch (error) {
+        console.error(`Ошибка при получении контракта эскроу: ${error}`);
+        throw new Error(`Не удалось получить или проверить контракт эскроу по адресу ${escrowAddressStr}: ${error}`);
+    }
+    
+    // Проверка и форматирование contestId перед возвратом
+    if (contestId === null || contestId === BigInt(0)) {
+        console.warn("Внимание: contestId всё ещё null или 0, пробуем получить из lastId");
+
+        // Если доступна функция lastId, пробуем получить оттуда
+        if (hasLastIdFunction) {
+            try {
+                const newLastId = await contestFactory.lastId();
+                console.log(`Текущее значение lastId после создания конкурса: ${newLastId}`);
+
+                if (newLastId > initialLastId) {
+                    // Если lastId увеличился, используем его
+                    contestId = newLastId;
+                    console.log(`Используем lastId как contestId: ${contestId}`);
+                } else {
+                    // Если lastId не изменился, используем initialLastId + 1
+                    contestId = initialLastId + BigInt(1);
+                    console.log(`Используем initialLastId + 1 как contestId: ${contestId}`);
+                }
+            } catch (error) {
+                console.error(`Ошибка при получении lastId после создания: ${error}`);
+                contestId = BigInt(1);
+            }
+        } else {
+            // Если функция lastId недоступна, используем значение по умолчанию
+            contestId = BigInt(1);
+        }
+    } else {
+        // Преобразуем contestId в bigint на всякий случай (если вдруг это строка или число)
+        try {
+            contestId = BigInt(contestId.toString());
+        } catch (error) {
+            console.warn(`Невозможно преобразовать contestId в bigint: ${error}`);
+        }
+    }
+
+    // Логируем финальный результат
+    console.log(`Финальный результат: contestId=${contestId}, escrowAddress=${escrowAddress}`);
 
     return {
         contestId,
         escrow,
         escrowAddress,
-        transaction: tx
+        transaction: createTx,
+        receipt
     };
 }
 
-/**
- * Опции для имитации завершения конкурса
- */
-export interface SimulateContestEndOptions {
-    /** Адреса победителей */
-    winners: string[];
-    /** Адреса членов жюри для голосования */
-    jurors?: string[];
-    /** Пометить конкурс как заблокированный (по умолчанию: false) */
-    flagAsFraud?: boolean;
-    /** Результаты голосования */
-    votes?: Array<{
-        juror: string;
-        contestantAddress: string;
-        place: number;
-        comment: string;
-    }>;
-}
-
-/**
- * Имитирует завершение конкурса с голосованием и определением победителей
- * @param escrow - Контракт эскроу конкурса
- * @param admin - Администратор платформы
- * @param options - Опции для симуляции завершения
- * @returns Результат операции
- */
-export async function simulateContestEnd(
-    escrow: ContestEscrow,
-    admin: SignerWithAddress,
-    options: SimulateContestEndOptions
+export async function createContest(
+    contestFactory: ContestFactory,
+    feeManager: NetworkFeeManager,
+    creator: any,
+    options: CreateContestOptions = {}
 ): Promise<{
-    winners: string[];
-    places: number[];
+    contestId: bigint;
     escrow: ContestEscrow;
-    finalState: string;
 }> {
-    // Получаем информацию о конкурсе
-    try {
-        const contestInfo = await escrow.getContestInfo();
-        const distribution = await escrow.getDistribution();
-        const numPlaces = distribution.length;
-
-        // Проверяем, что у нас достаточно победителей
-        if (options.winners.length < numPlaces) {
-            throw new Error(`Not enough winners provided. Need at least ${numPlaces} winners.`);
-        }
-
-        // Если конкурс помечен как мошеннический, используем emergency withdraw
-        if (options.flagAsFraud) {
-            try {
-                await escrow.connect(admin).emergencyWithdraw("Fraud detected");
-            } catch (error) {
-                console.warn('Emergency withdraw failed:', error);
-            }
-
-            return {
-                winners: [],
-                places: [],
-                escrow,
-                finalState: 'EMERGENCY_WITHDRAWN'
-            };
-        }
-
-        // Получаем время окончания конкурса
-        const endTime = await escrow.endTime();
-        const currentTime = await time.latest();
-
-        // Если конкурс еще не закончился, перематываем время
-        if (currentTime < endTime) {
-            await time.increaseTo(Number(endTime) + 1);
-        }
-
-        // Подготавливаем данные победителей
-        const finalWinners = options.winners.slice(0, numPlaces);
-        const finalPlaces = Array.from({ length: finalWinners.length }, (_, i) => i + 1);
-
-        try {
-            // Объявляем победителей (только 2 параметра)
-            await escrow.connect(admin).declareWinners(finalWinners, finalPlaces);
-
-            return {
-                winners: finalWinners,
-                places: finalPlaces,
-                escrow,
-                finalState: 'FINALIZED'
-            };
-        } catch (error) {
-            console.error('Failed to declare winners:', error);
-            
-            return {
-                winners: [],
-                places: [],
-                escrow,
-                finalState: 'ERROR'
-            };
-        }
-    } catch (error) {
-        console.error('Failed to simulate contest end:', error);
-        return {
-            winners: [],
-            places: [],
-            escrow,
-            finalState: 'ERROR'
-        };
-    }
+    const result = await createTestContest(contestFactory, feeManager, creator, options);
+    return {
+        contestId: result.contestId,
+        escrow: result.escrow
+    };
 }
 
 /**
@@ -331,73 +660,93 @@ export async function simulateContestEnd(
  * @param escrow Контракт эскроу
  * @returns Текущее время после увеличения
  */
-export async function endContest(escrow: ContestEscrow): Promise<number> {
-    try {
-        const endTime = await escrow.endTime();
-        const currentTime = await time.latest();
+export async function simulateContestEnd(escrow: ContestEscrow): Promise<number> {
+    const endTime = await escrow.endTime();
+    const currentTime = await time.latest();
 
-        if (currentTime < endTime) {
-            await time.increaseTo(Number(endTime) + 1);
-        }
-
-        return await time.latest();
-    } catch (error) {
-        console.error('Failed to end contest:', error);
-        return await time.latest();
+    if (currentTime < endTime) {
+        await time.increaseTo(Number(endTime) + 1);
     }
+
+    return await time.latest();
 }
 
 /**
- * Генерирует массив случайных адресов для тестовых членов жюри
- * @param count - Количество адресов (по умолчанию 3)
+ * Создает параметры времени для конкурса
+ * @param currentTime Текущее время
+ * @param durationHours Продолжительность конкурса в часах
+ * @param delayHours Задержка начала конкурса в часах
+ * @returns Объект с временем начала и окончания конкурса
+ */
+export function createContestTimeParams(currentTime: number, durationHours: number = 24, delayHours: number = 1) {
+  const startTime = BigInt(currentTime + delayHours * 3600);
+  const endTime = BigInt(currentTime + (delayHours + durationHours) * 3600);
+  return { startTime, endTime };
+}
+
+/**
+ * Проверяет выплату призов победителям
+ * @param escrow Контракт эскроу
+ * @param winner Адрес победителя
+ * @param _expectedPrize Ожидаемая сумма приза
+ * @returns Полученная сумма приза
+ */
+export async function verifyPrizeClaim(escrow: ContestEscrow, winner: any, _expectedPrize: bigint): Promise<bigint> {
+  // Проверяем, что победитель еще не получил приз
+  const hasClaimedBefore = await escrow.hasClaimed(winner.address);
+  if (hasClaimedBefore) {
+    throw new Error(`Победитель ${winner.address} уже получил приз`);
+  }
+
+  // Баланс победителя до получения приза
+  const winnerBalanceBefore = await ethers.provider.getBalance(winner.address);
+
+  // Получение приза победителем
+  const claimTx = await escrow.connect(winner).claimPrize();
+  const receipt = await claimTx.wait();
+
+  // Учитываем газ, потраченный на транзакцию
+  const gasUsed = receipt ? receipt.gasUsed * receipt.gasPrice : BigInt(0);
+
+  // Проверяем, что победитель получил приз
+  const winnerBalanceAfter = await ethers.provider.getBalance(winner.address);
+  const actualReceived = winnerBalanceAfter + gasUsed - winnerBalanceBefore;
+
+  // Проверяем, что статус получения приза обновился
+  const hasClaimedAfter = await escrow.hasClaimed(winner.address);
+  if (!hasClaimedAfter) {
+    throw new Error(`Статус получения приза не обновился для ${winner.address}`);
+  }
+
+  return actualReceived;
+}
+
+/**
+ * Генерирует случайные адреса для членов жюри
+ * @param count Количество адресов для генерации
  * @returns Массив адресов
  */
-export async function generateTestJury(count: number = 3): Promise<string[]> {
-    const jurors: string[] = [];
-    const signers = await ethers.getSigners();
-
-    // Используем адреса из доступных signers, начиная с 5-го
-    const startIndex = 5;
+export function generateTestJury(count: number): string[] {
+    const jury: string[] = [];
     for (let i = 0; i < count; i++) {
-        if (startIndex + i < signers.length) {
-            jurors.push(await signers[startIndex + i].getAddress());
-        } else {
-            // Если не хватает signers, создаем новый случайный адрес
-            const wallet = ethers.Wallet.createRandom();
-            jurors.push(wallet.address);
-        }
+        jury.push(ethers.Wallet.createRandom().address);
     }
-
-    return jurors;
+    return jury;
 }
 
 /**
- * Генерирует массив случайных адресов для тестовых победителей
- * @param count - Количество адресов (по умолчанию 3)
+ * Генерирует случайные адреса для победителей
+ * @param count Количество адресов для генерации
  * @returns Массив адресов
  */
-export async function generateTestWinners(count: number = 3): Promise<string[]> {
+export function generateTestWinners(count: number): string[] {
     const winners: string[] = [];
-    const signers = await ethers.getSigners();
-
-    // Используем адреса из доступных signers, начиная с 10-го
-    const startIndex = 10;
     for (let i = 0; i < count; i++) {
-        if (startIndex + i < signers.length) {
-            winners.push(await signers[startIndex + i].getAddress());
-        } else {
-            // Если не хватает signers, создаем новый случайный адрес
-            const wallet = ethers.Wallet.createRandom();
-            winners.push(wallet.address);
-        }
+        winners.push(ethers.Wallet.createRandom().address);
     }
-
     return winners;
 }
 
-export {
-    createTestContest as createContest,
-    simulateContestEnd as simulateContest,
-    generateTestJury as generateJury,
-    generateTestWinners as generateWinners
-};
+export { simulateContestEnd as endContest };
+export { generateTestJury as generateJury };
+export { generateTestWinners as generateWinners };

--- a/test/helpers/TokenHelper.ts
+++ b/test/helpers/TokenHelper.ts
@@ -77,21 +77,11 @@ export async function prepareERC20Token(
     console.log(`🔧 Preparing ERC20 token for ${account.address}, amount: ${amount}`);
 
     try {
-        // Получаем минимальную информацию о токене для отладки
+        // Получаем информацию о токене для отладки
+        const tokenName = await tokenContract.name();
         const tokenSymbol = await tokenContract.symbol();
-        const tokenAddress = await tokenContract.getAddress();
-        console.log(`📝 Информация о токене: ${tokenSymbol}, address: ${tokenAddress}`);
-
-        // Проверяем валидность токена до любых операций
-        if (tokenValidator) {
-            try {
-                const isValid = await tokenValidator.isValidToken(tokenAddress).catch(() => false);
-                const isStable = await tokenValidator.isStablecoin?.(tokenAddress).catch(() => false);
-                console.log(`🔍 Статус токена перед операциями: isValid=${isValid}, isStablecoin=${isStable}`);
-            } catch (validationError) {
-                console.log(`⚠️ Не удалось проверить статус токена: ${validationError}`);
-            }
-        }
+        const tokenDecimals = await tokenContract.decimals();
+        console.log(`📝 Информация о токене: ${tokenName} (${tokenSymbol}), decimals: ${tokenDecimals}`);
 
         // 1. Проверяем текущий баланс
         const currentBalance = await tokenContract.balanceOf(account.address);
@@ -518,7 +508,7 @@ export const BALANCE_SCENARIOS = {
         weth: toTokenUnits(1, 18),        // 1 WETH
         eth: ethers.parseEther("10")      // 10 ETH
     },
-
+    
     // Средние балансы для большинства тестов
     STANDARD: {
         usdc: toTokenUnits(100000, 6),    // 100,000 USDC
@@ -526,7 +516,7 @@ export const BALANCE_SCENARIOS = {
         weth: toTokenUnits(50, 18),       // 50 WETH
         eth: ethers.parseEther("100")     // 100 ETH
     },
-
+    
     // Большие балансы для стресс-тестов
     LARGE: {
         usdc: toTokenUnits(10000000, 6),  // 10M USDC

--- a/test/integration/ContestTokens.test.ts
+++ b/test/integration/ContestTokens.test.ts
@@ -1,360 +1,510 @@
 import { expect } from "chai";
 import { ethers } from "hardhat";
-import { loadFixture, time } from "@nomicfoundation/hardhat-toolbox/network-helpers";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { time } from "@nomicfoundation/hardhat-toolbox/network-helpers";
+import {
+  ContestFactory,
+  NetworkFeeManager,
+  TokenValidator,
+  MockUSDT,
+  MockUSDC
+} from "../../typechain-types";
+import { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
 import { 
-    TEST_CONSTANTS, 
-    deployFullPlatformFixture 
-} from "../fixtures";
-import { 
-    createTestContest, 
-    endContest
+  createTestContest, 
+  endContest,
+  createContestTimeParams,
+  generateTestJury
 } from "../helpers/ContestHelper";
+import { deployTokenValidatorFixture } from "../fixtures";
 
-describe("ContestTokens", function () {
-    this.timeout(120000);
+describe("Contest Token Integration Tests", function() {
+  // Увеличиваем timeout для интеграционных тестов
+  this.timeout(120000);
 
-    describe("Инициализация конкурсов с различными токенами", function () {
-        it("должен корректно инициализировать конкурс с ETH", async function () {
-            const fixture = await loadFixture(deployFullPlatformFixture);
+  // Объявление переменных
+  let contestFactory: ContestFactory;
+  let networkFeeManager: NetworkFeeManager;
+  let tokenValidator: TokenValidator;
 
-            // Создаем конкурс с ETH
-            const { contestId, escrow } = await createTestContest(
-                fixture.contestFactory,
-                fixture.feeManager,
-                fixture.creator1,
-                {
-                    name: "ETH конкурс",
-                    description: "Конкурс с призом в ETH",
-                    paymentToken: ethers.ZeroAddress, // Явно указываем ETH
-                    prizeAmount: TEST_CONSTANTS.SMALL_PRIZE,
-                    submissionDeadline: Math.floor(Date.now() / 1000) + 7200
-                }
-            );
+  let owner: SignerWithAddress;
+  let creator: SignerWithAddress;
+  let winner: SignerWithAddress;
+  let juryMember: SignerWithAddress;
+  let treasury: SignerWithAddress;
 
-            // Проверяем параметры конкурса
-            const params = await escrow.getContestParams();
-            expect(params.contestId).to.equal(contestId);
-            expect(params.creator).to.equal(fixture.creator1.address);
-            expect(params.totalPrize).to.equal(TEST_CONSTANTS.SMALL_PRIZE);
-            expect(await escrow.token()).to.equal(ethers.ZeroAddress);
+  let mockUSDT: MockUSDT;
+  let mockUSDC: MockUSDC;
 
-            // Проверяем баланс эскроу
-            const balance = await ethers.provider.getBalance(await escrow.getAddress());
-            expect(balance).to.equal(TEST_CONSTANTS.SMALL_PRIZE);
+  // Упрощенная фикстура для развертывания контрактов
+  async function deployContractsFixture() {
+    [owner, creator, winner, juryMember, treasury] = await ethers.getSigners();
+
+    // 1. Развертываем токены и валидатор
+    const tokenFixture = await deployTokenValidatorFixture();
+    tokenValidator = tokenFixture.tokenValidator;
+    mockUSDT = tokenFixture.mockUSDT;
+    mockUSDC = tokenFixture.mockUSDC;
+
+    // 2. NetworkFeeManager
+    const NetworkFeeManager = await ethers.getContractFactory("NetworkFeeManager");
+    networkFeeManager = await NetworkFeeManager.deploy(treasury.address);
+    await networkFeeManager.waitForDeployment();
+
+    // 3. Остальные контракты
+    const PrizeTemplates = await ethers.getContractFactory("PrizeTemplates");
+    const prizeTemplates = await PrizeTemplates.deploy();
+    await prizeTemplates.waitForDeployment();
+
+    const PrizeManager = await ethers.getContractFactory("PrizeManager");
+    const prizeManager = await PrizeManager.deploy();
+    await prizeManager.waitForDeployment();
+
+    const CreatorBadges = await ethers.getContractFactory("CreatorBadges");
+    const creatorBadges = await CreatorBadges.deploy();
+    await creatorBadges.waitForDeployment();
+
+    const ContestEscrow = await ethers.getContractFactory("ContestEscrow");
+    const contestEscrow = await ContestEscrow.deploy();
+    await contestEscrow.waitForDeployment();
+
+    // 4. ContestFactory
+    const ContestFactory = await ethers.getContractFactory("ContestFactory");
+    contestFactory = await ContestFactory.deploy(
+        await contestEscrow.getAddress(),
+        await networkFeeManager.getAddress(),
+        await prizeTemplates.getAddress(),
+        await creatorBadges.getAddress(),
+        await tokenValidator.getAddress(),
+        await prizeManager.getAddress()
+    );
+    await contestFactory.waitForDeployment();
+
+    // 5. Настройка контрактов
+    await networkFeeManager.setNetworkFee(31337, 200); // 2%
+    await networkFeeManager.setContestFactory(await contestFactory.getAddress());
+    await prizeManager.setAuthorizedCreator(await contestFactory.getAddress(), true);
+    await creatorBadges.setContestFactory(await contestFactory.getAddress());
+
+    // 6. Подготовка токенов
+    const tokenAmount = ethers.parseUnits("10000", 18);
+    
+    // Минт токенов создателю
+    await mockUSDT.mint(creator.address, tokenAmount);
+    await mockUSDC.mint(creator.address, tokenAmount);
+
+    // Одобрения
+    await mockUSDT.connect(creator).approve(await contestFactory.getAddress(), tokenAmount);
+    await mockUSDC.connect(creator).approve(await contestFactory.getAddress(), tokenAmount);
+
+    return {
+      contestFactory,
+      networkFeeManager,
+      tokenValidator,
+      mockUSDT,
+      mockUSDC,
+      owner,
+      creator,
+      winner,
+      juryMember,
+      treasury
+    };
+  }
+
+  beforeEach(async function() {
+    const fixture = await loadFixture(deployContractsFixture);
+    Object.assign(this, fixture);
+  });
+
+  it("Полный жизненный цикл конкурса с USDT токеном", async function() {
+    console.log("🚀 Создание конкурса с USDT призом");
+
+    const totalPrize = ethers.parseUnits("100", await mockUSDT.decimals());
+    const currentTime = await time.latest();
+    const {startTime, endTime} = createContestTimeParams(currentTime, 24, 1);
+
+    const contestResult = await createTestContest(
+      contestFactory,
+      networkFeeManager,
+      creator,
+      {
+        token: await mockUSDT.getAddress(),
+        totalPrize: totalPrize,
+        template: 1,
+        startTime: startTime,
+        endTime: endTime,
+        jury: [juryMember.address],
+        metadata: {
+          title: "USDT Test Contest",
+          description: "Testing full contest lifecycle with USDT"
+        }
+      }
+    );
+
+    const { contestId, escrow, escrowAddress } = contestResult;
+    console.log(`Конкурс создан: ID=${contestId}, адрес эскроу=${escrowAddress}`);
+
+    // Проверки
+    expect(contestId).to.be.gt(BigInt(0));
+    expect(escrowAddress).to.not.equal(ethers.ZeroAddress);
+
+    const escrowBalance = await mockUSDT.balanceOf(escrowAddress);
+    expect(escrowBalance).to.equal(totalPrize);
+
+    // Начало конкурса
+    console.log("⏱️ Ожидание начала конкурса");
+    await time.increaseTo(Number(startTime) + 10);
+
+    // Завершение конкурса
+    console.log("🏁 Завершение конкурса");
+    await endContest(escrow);
+
+    // Объявление победителя
+    console.log("🏆 Объявление победителя");
+    const winners = [winner.address];
+    const places = [1];
+
+    await escrow.connect(juryMember).declareWinners(winners, places);
+
+    // Получение приза
+    console.log("💰 Получение приза");
+    const winnerBalanceBefore = await mockUSDT.balanceOf(winner.address);
+    
+    await escrow.connect(winner).claimPrize();
+    
+    const winnerBalanceAfter = await mockUSDT.balanceOf(winner.address);
+    const received = winnerBalanceAfter - winnerBalanceBefore;
+    
+    expect(received).to.be.gt(0);
+    console.log("✅ Тест успешно завершен");
+  });
+
+  it("Создание конкурсов с различными типами токенов", async function() {
+    console.log("💎 Создание конкурса с ETH");
+    
+    // ETH конкурс
+    const ethTotalPrize = ethers.parseEther("1");
+    const currentTime = await time.latest();
+    const {startTime: ethStartTime, endTime: ethEndTime} = createContestTimeParams(currentTime, 24, 1);
+
+    const ethContestResult = await createTestContest(
+      contestFactory,
+      networkFeeManager,
+      creator,
+      {
+        token: ethers.ZeroAddress,
+        totalPrize: ethTotalPrize,
+        template: 0,
+        startTime: ethStartTime,
+        endTime: ethEndTime,
+        metadata: {
+          title: "ETH Contest",
+          description: "Contest with ETH prize"
+        }
+      }
+    );
+
+    expect(ethContestResult.contestId).to.be.gt(BigInt(0));
+
+    // USDC конкурс
+    console.log("💵 Создание конкурса с USDC");
+    
+    // Убеждаемся, что USDC настроен как стейблкоин
+    try {
+      const [owner] = await ethers.getSigners();
+
+      // Сначала проверим текущее состояние
+      const isValid = await tokenValidator.isValidToken(await mockUSDC.getAddress());
+      const isStable = await tokenValidator.isStablecoin(await mockUSDC.getAddress());
+      console.log(`USDC перед настройкой: isValid=${isValid}, isStable=${isStable}`);
+
+      // Добавляем USDC в whitelist (гарантируем, что используем owner)
+      if (!isValid) {
+        await tokenValidator.connect(owner).setTokenWhitelist(await mockUSDC.getAddress(), true, "USDC for test");
+        console.log("✅ USDC добавлен в whitelist");
+      }
+
+      if (!isStable) {
+        console.log("Попробуем добавить USDC как стейблкоин через прямое добавление в whitelist с признаком стейблкоина");
+
+        // Проверим информацию о токене
+        const tokenInfo = await mockUSDC.name();
+        const tokenSymbol = await mockUSDC.symbol();
+        const tokenDecimals = await mockUSDC.decimals();
+        console.log(`Информация о токене: ${tokenInfo} (${tokenSymbol}), decimals: ${tokenDecimals}`);
+
+        // Этот подход должен сработать для любой имплементации TokenValidator
+        try {
+          // Добавляем токен в whitelist с признаком, что это стейблкоин
+          await tokenValidator.connect(owner).setTokenWhitelist(await mockUSDC.getAddress(), true, 
+              "USDC stablecoin for test");
+
+          // Проверяем информацию о токене через TokenInfo (если доступно)
+          try {
+            const info = await tokenValidator.tokenInfoCache?.(await mockUSDC.getAddress());
+            console.log(`Информация из кеша о токене: ${JSON.stringify(info || 'недоступно')}`);
+          } catch (cacheErr) {
+            console.log(`Не удалось получить информацию из кеша: ${cacheErr instanceof Error ? cacheErr.message : String(cacheErr)}`);
+          }
+
+          console.log("✅ USDC добавлен в whitelist с указанием, что это стейблкоин");
+        } catch (whitelistErr) {
+          console.error(`⛔ Не удалось обновить whitelist для USDC: ${whitelistErr}`);
+        }
+      }
+
+      // Проверяем еще раз после настройки
+      const isValidAfter = await tokenValidator.isValidToken(await mockUSDC.getAddress());
+      const isStableAfter = await tokenValidator.isStablecoin(await mockUSDC.getAddress());
+      console.log(`USDC после настройки: isValid=${isValidAfter}, isStable=${isStableAfter}`);
+
+    } catch (error) {
+      console.log(`Предупреждение: не удалось настроить USDC: ${error}`);
+    }
+
+    // Проверяем баланс и разрешения перед созданием конкурса
+    const usdcTotalPrize = ethers.parseUnits("50", await mockUSDC.decimals());
+    const usdcFee = await networkFeeManager.calculateFee(31337, usdcTotalPrize);
+    const usdcTotal = usdcTotalPrize + usdcFee;
+
+    console.log(`USDC: приз=${usdcTotalPrize}, комиссия=${usdcFee}, всего=${usdcTotal}`);
+    console.log(`Баланс USDC у создателя: ${await mockUSDC.balanceOf(creator.address)}`);
+    console.log(`Разрешение USDC: ${await mockUSDC.allowance(creator.address, await contestFactory.getAddress())}`);
+
+    // Обновляем разрешение для большей уверенности
+    await mockUSDC.connect(creator).approve(await contestFactory.getAddress(), ethers.parseUnits("1000", await mockUSDC.decimals()));
+    console.log(`Новое разрешение USDC: ${await mockUSDC.allowance(creator.address, await contestFactory.getAddress())}`);
+
+    const {startTime: usdcStartTime, endTime: usdcEndTime} = createContestTimeParams(currentTime, 72, 2);
+
+    // Объявляем переменную вне блока try
+    let usdcContestResult;
+
+    try {
+      console.log("Попытка создания конкурса с USDC...");
+
+      // Проверяем фактический баланс и разрешения перед созданием
+      console.log(`Баланс USDC перед созданием: ${await mockUSDC.balanceOf(creator.address)}`);
+      console.log(`Разрешение USDC перед созданием: ${await mockUSDC.allowance(creator.address, await contestFactory.getAddress())}`);
+
+      // Проверка существующих конкурсов
+      try {
+        const lastId = await contestFactory.lastId();
+        console.log(`Текущее количество конкурсов (lastId): ${lastId}`);
+      } catch (err) {
+        console.log(`Не удалось получить lastId: ${err instanceof Error ? err.message : String(err)}`);
+      }
+
+      // Увеличиваем лимит газа для более надежного создания конкурса
+      const gasLimit = 12000000; // Увеличиваем еще больше
+      console.log(`Используем увеличенный gasLimit: ${gasLimit}`);
+
+      // Пробуем создать конкурс напрямую через контракт, обходя helper
+      const usdcAddress = await mockUSDC.getAddress();
+
+      // Обеспечиваем дополнительный approve
+      await mockUSDC.connect(creator).approve(await contestFactory.getAddress(), usdcTotal * BigInt(2));
+      console.log(`Обновленное разрешение USDC: ${await mockUSDC.allowance(creator.address, await contestFactory.getAddress())}`);
+
+      // Создаем параметры для прямого вызова
+      const contestParams = {
+        token: mockUSDC,
+        totalPrize: usdcTotalPrize,
+        template: 0,
+        customDistribution: [],
+        jury: [creator.address],
+        startTime: usdcStartTime,
+        endTime: usdcEndTime,
+        contestMetadata: JSON.stringify({
+          title: "USDC Contest",
+          description: "Contest with USDC prize"
+        }),
+        hasNonMonetaryPrizes: false
+      };
+
+      console.log("Прямой вызов createContest с настроенным USDC токеном...");
+
+      try {
+        // Пробуем напрямую вызвать метод с контрактом
+        const tx = await contestFactory.connect(creator).createContest(contestParams, {
+          gasLimit: gasLimit
         });
 
-        it("должен корректно инициализировать конкурс с USDC", async function () {
-            const fixture = await loadFixture(deployFullPlatformFixture);
+        console.log(`Транзакция отправлена: ${tx.hash}`);
+        const receipt = await tx.wait();
+        console.log(`✅ Транзакция подтверждена: ${receipt?.hash || 'нет хеша'}`);
 
-            // Получаем адрес USDC токена
-            const usdcAddress = await fixture.mockUSDC.getAddress();
-            console.log(`Адрес USDC: ${usdcAddress}`);
+        // Получаем ID конкурса из событий
+        let contestId;
+        if (receipt && receipt.logs) {
+          for (const log of receipt.logs) {
+            try {
+              const parsed = contestFactory.interface.parseLog({
+                topics: log.topics,
+                data: log.data
+              });
 
-            // Проверяем баланс USDC у создателя
-            const creatorBalance = await fixture.mockUSDC.balanceOf(fixture.creator1.address);
-            console.log(`Баланс USDC создателя: ${ethers.formatUnits(creatorBalance, 6)}`);
-
-            // Проверяем, одобрен ли токен для фабрики
-            const factoryAddress = await fixture.contestFactory.getAddress();
-            const allowance = await fixture.mockUSDC.allowance(fixture.creator1.address, factoryAddress);
-            console.log(`Текущее одобрение USDC: ${ethers.formatUnits(allowance, 6)}`);
-
-            // Если одобрения нет, делаем его
-            if (allowance < ethers.parseUnits("1000", 6)) {
-                await fixture.mockUSDC.connect(fixture.creator1).approve(
-                    factoryAddress,
-                    ethers.parseUnits("10000", 6)
-                );
-                console.log("Одобрение USDC выполнено");
+              if (parsed && parsed.name === "ContestCreated") {
+                contestId = parsed.args.contestId;
+                console.log(`✅ Конкурс создан: ID=${contestId}`);
+                break;
+              }
+            } catch (e) {
+              // Игнорируем ошибки парсинга
             }
+          }
+        }
 
-            // Создаем конкурс с USDC
-            const { contestId, escrow } = await createTestContest(
-                fixture.contestFactory,
-                fixture.feeManager,
-                fixture.creator1,
-                {
-                    name: "USDC конкурс",
-                    description: "Конкурс с призом в USDC",
-                    paymentToken: usdcAddress,
-                    prizeAmount: ethers.parseUnits("1000", 6) // 1000 USDC
-                }
-            );
+        if (!contestId) {
+          console.log("⚠️ Не удалось получить ID из событий, пробуем lastId");
+          const lastId = await contestFactory.lastId();
+          contestId = lastId;
+          console.log(`Используем lastId как contestId: ${contestId}`);
+        }
 
-            // Получаем параметры конкурса
-            const params = await escrow.getContestParams();
+        // Теперь получаем эскроу контракт
+        const escrowAddress = await contestFactory.escrows(Number(contestId) - 1);
+        const escrow = await ethers.getContractAt("ContestEscrow", escrowAddress);
 
-            // Получаем адрес токена напрямую из контракта
-            const tokenAddress = await escrow.token();
+        usdcContestResult = {
+          contestId,
+          escrow,
+          escrowAddress,
+          transaction: tx,
+          receipt
+        };
 
-            // Проверяем корректность данных
-            expect(tokenAddress).to.equal(usdcAddress);
-            expect(params.totalPrize).to.equal(ethers.parseUnits("1000", 6));
-        });
+      } catch (directError) {
+        console.error(`❌ Ошибка при прямом вызове createContest: ${directError}`);
+        console.error(`Детали ошибки: ${JSON.stringify(directError, (_, v) => 
+          typeof v === 'bigint' ? v.toString() : v, 2)}`);
 
+        // Возвращаемся к использованию helper
+        console.log("Возвращаемся к использованию helper createTestContest...");
+        usdcContestResult = await createTestContest(
+          contestFactory,
+          networkFeeManager,
+          creator,
+          {
+            token: usdcAddress,
+            totalPrize: usdcTotalPrize,
+            template: 0,
+            startTime: usdcStartTime,
+            endTime: usdcEndTime,
+            metadata: {
+              title: "USDC Contest",
+              description: "Contest with USDC prize"
+            }
+          }
+        );
+      }
 
-        it("должен корректно инициализировать конкурс с WETH", async function () {
-            const fixture = await loadFixture(deployFullPlatformFixture);
+      console.log(`✅ Конкурс с USDC создан успешно! ID: ${usdcContestResult.contestId}`);
+    } catch (error) {
+      console.error(`❌ Ошибка при создании конкурса с USDC: ${error}`);
+      throw error; // Пробрасываем ошибку дальше для провала теста
+    }
 
-            const { escrow } = await createTestContest(
-                fixture.contestFactory,
-                fixture.feeManager,
-                fixture.creator1,
-                {
-                    paymentToken: await fixture.mockWETH.getAddress(),
-                    prizeAmount: TEST_CONSTANTS.MEDIUM_PRIZE,
-                    submissionDeadline: Math.floor(Date.now() / 1000) + 3600
-                }
-            );
+    expect(usdcContestResult.contestId).to.be.gt(BigInt(0));
+    expect(usdcContestResult.contestId).to.be.gt(ethContestResult.contestId);
 
-            const params = await escrow.getContestParams();
-            expect(await escrow.token()).to.equal(await fixture.mockWETH.getAddress());
-            expect(params.totalPrize).to.equal(TEST_CONSTANTS.MEDIUM_PRIZE);
+    console.log("✅ Тест с различными токенами успешно завершен");
+  });
 
-            const tokenBalance = await fixture.mockWETH.balanceOf(await escrow.getAddress());
-            expect(tokenBalance).to.equal(TEST_CONSTANTS.MEDIUM_PRIZE);
-        });
-    });
+  it("Проверка валидации токенов через TokenValidator", async function() {
+    console.log("🔍 Проверка валидности токена USDT");
+    
+    const isUsdtValid = await tokenValidator.isValidToken(await mockUSDT.getAddress());
+    console.log(`USDT валиден: ${isUsdtValid}`);
 
-    describe("Обработка призов в различных токенах", function () {
-        it("должен корректно распределять ETH призы", async function () {
-            const fixture = await loadFixture(deployFullPlatformFixture);
+    const usdtInfo = await tokenValidator.getTokenInfo(await mockUSDT.getAddress());
+    console.log(`USDT информация: hasLiquidity=${usdtInfo.hasLiquidity}, isStablecoin=${usdtInfo.isStablecoin}`);
 
-            const { escrow } = await createTestContest(
-                fixture.contestFactory,
-                fixture.feeManager,
-                fixture.creator1,
-                {
-                    prizeAmount: TEST_CONSTANTS.MEDIUM_PRIZE,
-                    submissionDeadline: Math.floor(Date.now() / 1000) + 3600
-                }
-            );
+    const isUsdtStablecoin = await tokenValidator.isStablecoin(await mockUSDT.getAddress());
+    expect(isUsdtStablecoin).to.be.true;
 
-            await endContest(escrow);
+    // Создание конкурса для проверки валидации
+    const totalPrize = ethers.parseUnits("100", await mockUSDT.decimals());
+    const currentTime = await time.latest();
+    const {startTime, endTime} = createContestTimeParams(currentTime, 24, 1);
 
-            await escrow.connect(fixture.creator1)
-                .declareWinners(
-                    [fixture.winner1.address, fixture.winner2.address, fixture.winner3.address],
-                    [1, 2, 3]
-                );
+    const contestResult = await createTestContest(
+      contestFactory,
+      networkFeeManager,
+      creator,
+      {
+        token: await mockUSDT.getAddress(),
+        totalPrize: totalPrize,
+        template: 0,
+        startTime: startTime,
+        endTime: endTime,
+        metadata: {
+          title: "USDT Validation Test",
+          description: "Testing token validation"
+        }
+      }
+    );
 
-            const balanceBefore = await ethers.provider.getBalance(fixture.winner1.address);
+    expect(contestResult.contestId).to.be.gt(BigInt(0));
+    console.log("✅ Тест валидации токенов успешно завершен");
+  });
 
-            // Проверяем значение константы
-            console.log(`Значение константы MEDIUM_PRIZE: ${TEST_CONSTANTS.MEDIUM_PRIZE}`);
-            console.log(`В ETH: ${ethers.formatEther(TEST_CONSTANTS.MEDIUM_PRIZE)}`);
+  it("Проверка расчета комиссий для различных токенов", async function() {
+    console.log("💼 Проверка комиссий");
 
-            // Забираем приз
-            const tx = await escrow.connect(fixture.winner1).claimPrize();
-            const receipt = await tx.wait();
+    // ETH конкурс
+    const ethTotalPrize = ethers.parseEther("10");
+    const ethFee = await networkFeeManager.calculateFee(31337, ethTotalPrize);
+    const currentTime = await time.latest();
+    const {startTime: ethStartTime, endTime: ethEndTime} = createContestTimeParams(currentTime, 24, 1);
 
-            // Вычисляем газовые затраты
-            const gasUsed = receipt ? receipt.gasUsed * receipt.gasPrice : 0n;
+    await createTestContest(
+      contestFactory,
+      networkFeeManager,
+      creator,
+      {
+        token: ethers.ZeroAddress,
+        totalPrize: ethTotalPrize,
+        template: 0,
+        startTime: ethStartTime,
+        endTime: ethEndTime,
+        metadata: {
+          title: "ETH Fee Test",
+          description: "Testing fee calculation with ETH"
+        }
+      }
+    );
 
-            const balanceAfter = await ethers.provider.getBalance(fixture.winner1.address);
+    // Проверяем комиссию ETH
+    const availableETHFees = await networkFeeManager.getAvailableETHFees();
+    expect(availableETHFees).to.equal(ethFee);
 
-            // Проверяем, что баланс увеличился на сумму приза минус газ
-            // По результатам тестов, фактический приз составляет 7 ETH
-            // Это связано с тем, что хотя MEDIUM_PRIZE = 10 ETH, при использовании
-            // распределения призов TOP_2 первое место получает 70% от общего приза,
-            // что составляет 7 ETH от 10 ETH
-            const actualPrize = ethers.parseEther("6.0");
+    // USDT конкурс
+    const usdtTotalPrize = ethers.parseUnits("1000", await mockUSDT.decimals());
+    const usdtFee = await networkFeeManager.calculateFee(31337, usdtTotalPrize);
+    const {startTime: usdtStartTime, endTime: usdtEndTime} = createContestTimeParams(currentTime, 24, 2);
 
-            // Проверяем с фактическим призом
-            expect(balanceAfter).to.equal(balanceBefore + actualPrize - gasUsed);
+    await createTestContest(
+      contestFactory,
+      networkFeeManager,
+      creator,
+      {
+        token: await mockUSDT.getAddress(),
+        totalPrize: usdtTotalPrize,
+        template: 0,
+        startTime: usdtStartTime,
+        endTime: usdtEndTime,
+        metadata: {
+          title: "USDT Fee Test",
+          description: "Testing fee calculation with USDT"
+        }
+      }
+    );
 
-            // Добавляем подробное логирование для диагностики
-            console.log(`Баланс до: ${balanceBefore}`);
-            console.log(`Баланс после: ${balanceAfter}`);
-            console.log(`Разница: ${balanceAfter - balanceBefore}`);
-            console.log(`Ожидаемый приз по константе: ${TEST_CONSTANTS.MEDIUM_PRIZE}`);
-            console.log(`Фактический приз: ${actualPrize}`);
-            console.log(`Газовые затраты: ${gasUsed}`);
+    // Проверяем комиссию USDT
+    const availableUSDTFees = await networkFeeManager.getAvailableTokenFees(await mockUSDT.getAddress());
+    expect(availableUSDTFees).to.equal(usdtFee);
 
-            // Дополнительная проверка: баланс должен увеличиться
-            expect(balanceAfter).to.be.gt(balanceBefore);
-
-            // Вычисляем чистое увеличение с учетом газа для диагностики
-            const netIncrease = balanceAfter - balanceBefore + gasUsed;
-            console.log(`Чистое увеличение (с учетом газа): ${netIncrease}`);
-        });
-
-        it("должен корректно распределять USDC призы", async function () {
-            const fixture = await loadFixture(deployFullPlatformFixture);
-
-            const { escrow } = await createTestContest(
-                fixture.contestFactory,
-                fixture.feeManager,
-                fixture.creator1,
-                {
-                    paymentToken: await fixture.mockUSDC.getAddress(),
-                    prizeAmount: TEST_CONSTANTS.MEDIUM_PRIZE,
-                    submissionDeadline: Math.floor(Date.now() / 1000) + 3600
-                }
-            );
-
-            await endContest(escrow);
-
-            // Объявляем двух победителей
-            await escrow.connect(fixture.creator1)
-                .declareWinners([fixture.winner1.address, fixture.winner2.address], [1, 2]);
-
-            // Проверяем баланс первого победителя до и после получения приза
-            const balanceBefore = await fixture.mockUSDC.balanceOf(fixture.winner1.address);
-            await escrow.connect(fixture.winner1).claimPrize();
-            const balanceAfter = await fixture.mockUSDC.balanceOf(fixture.winner1.address);
-
-            // По шаблону TOP_2, первое место получает 70%
-            const expectedPrize = TEST_CONSTANTS.MEDIUM_PRIZE * 7000n / 10000n;
-            expect(balanceAfter - balanceBefore).to.equal(expectedPrize);
-
-            // Проверяем баланс второго победителя
-            const balance2Before = await fixture.mockUSDC.balanceOf(fixture.winner2.address);
-            await escrow.connect(fixture.winner2).claimPrize();
-            const balance2After = await fixture.mockUSDC.balanceOf(fixture.winner2.address);
-
-            // Второе место получает 30%
-            const expectedPrize2 = TEST_CONSTANTS.MEDIUM_PRIZE * 3000n / 10000n;
-            expect(balance2After - balance2Before).to.equal(expectedPrize2);
-        });
-    });
-
-    describe("Проверка комиссий при использовании различных токенов", function () {
-        it("должен правильно рассчитывать комиссию платформы для ETH", async function () {
-            const fixture = await loadFixture(deployFullPlatformFixture);
-
-            // Устанавливаем комиссию 5%
-            await fixture.feeManager.setNetworkFee(31337, 500);
-
-            const totalPrize = TEST_CONSTANTS.MEDIUM_PRIZE;
-            // Используем логику округления вверх, как в контракте
-            const expectedFee = (totalPrize * 500n + 9999n) / 10000n; // 5% с округлением вверх
-
-            const treasuryBalanceBefore = await ethers.provider.getBalance(fixture.treasury.address);
-
-            // Создаем конкурс с ETH
-            await createTestContest(
-                fixture.contestFactory,
-                fixture.feeManager,
-                fixture.creator1,
-                {
-                    prizeAmount: totalPrize,
-                    submissionDeadline: Math.floor(Date.now() / 1000) + 3600
-                }
-            );
-
-            const treasuryBalanceAfter = await ethers.provider.getBalance(fixture.treasury.address);
-
-            // Проверяем, что казначейство получило комиссию
-            expect(treasuryBalanceAfter - treasuryBalanceBefore).to.equal(expectedFee);
-        });
-
-        it("должен правильно рассчитывать комиссию платформы для ERC20", async function () {
-            const fixture = await loadFixture(deployFullPlatformFixture);
-
-            // Устанавливаем комиссию 2.5%
-            await fixture.feeManager.setNetworkFee(31337, 250);
-
-            const totalPrize = TEST_CONSTANTS.MEDIUM_PRIZE;
-            // Используем логику округления вверх, как в контракте
-            const expectedFee = (totalPrize * 250n + 9999n) / 10000n; // 2.5% с округлением вверх
-
-            const treasuryBalanceBefore = await fixture.mockUSDT.balanceOf(fixture.treasury.address);
-
-            // Создаем конкурс с USDT
-            await createTestContest(
-                fixture.contestFactory,
-                fixture.feeManager,
-                fixture.creator1,
-                {
-                    paymentToken: await fixture.mockUSDT.getAddress(),
-                    prizeAmount: totalPrize,
-                    submissionDeadline: Math.floor(Date.now() / 1000) + 3600
-                }
-            );
-
-            const treasuryBalanceAfter = await fixture.mockUSDT.balanceOf(fixture.treasury.address);
-
-            // Проверяем, что казначейство получило комиссию
-            expect(treasuryBalanceAfter - treasuryBalanceBefore).to.equal(expectedFee);
-        });
-    });
-
-    describe("Проверка возврата средств при отмене конкурса", function () {
-        it("должен возвращать ETH создателю при отмене", async function () {
-            const fixture = await loadFixture(deployFullPlatformFixture);
-
-            const { escrow } = await createTestContest(
-                fixture.contestFactory,
-                fixture.feeManager,
-                fixture.creator1,
-                {
-                    prizeAmount: TEST_CONSTANTS.MEDIUM_PRIZE,
-                    submissionDeadline: Math.floor(Date.now() / 1000) + 7200
-                }
-            );
-
-            const balanceBefore = await ethers.provider.getBalance(fixture.creator1.address);
-
-            // Отменяем конкурс
-            const tx = await escrow.connect(fixture.creator1).cancel("Отмена тестового конкурса");
-            const receipt = await tx.wait();
-            const gasUsed = receipt ? receipt.gasUsed * receipt.gasPrice : 0n;
-
-            const balanceAfter = await ethers.provider.getBalance(fixture.creator1.address);
-
-            // Проверяем, что создатель получил средства обратно (за вычетом газа)
-            expect(balanceAfter).to.equal(balanceBefore + TEST_CONSTANTS.MEDIUM_PRIZE - gasUsed);
-        });
-
-        it("должен возвращать ERC20 токены создателю при отмене", async function () {
-            const fixture = await loadFixture(deployFullPlatformFixture);
-
-            const { escrow } = await createTestContest(
-                fixture.contestFactory,
-                fixture.feeManager,
-                fixture.creator1,
-                {
-                    paymentToken: await fixture.mockWETH.getAddress(),
-                    prizeAmount: TEST_CONSTANTS.MEDIUM_PRIZE,
-                    submissionDeadline: Math.floor(Date.now() / 1000) + 7200
-                }
-            );
-
-            const balanceBefore = await fixture.mockWETH.balanceOf(fixture.creator1.address);
-
-            // Отменяем конкурс
-            await escrow.connect(fixture.creator1).cancel("Отмена тестового конкурса");
-
-            const balanceAfter = await fixture.mockWETH.balanceOf(fixture.creator1.address);
-
-            // Проверяем, что создатель получил токены обратно
-            expect(balanceAfter - balanceBefore).to.equal(TEST_CONSTANTS.MEDIUM_PRIZE);
-        });
-    });
-
-    describe("Валидация токенов", function () {
-        it("должен проверять валидность ERC20 токенов", async function () {
-            const fixture = await loadFixture(deployFullPlatformFixture);
-
-            // Проверяем, что наши тестовые токены валидны
-            expect(await fixture.tokenValidator.isValidToken(await fixture.mockUSDC.getAddress())).to.be.true;
-            expect(await fixture.tokenValidator.isValidToken(await fixture.mockUSDT.getAddress())).to.be.true;
-            expect(await fixture.tokenValidator.isValidToken(await fixture.mockWETH.getAddress())).to.be.true;
-
-            // Проверяем нативный токен (ETH)
-            expect(await fixture.tokenValidator.isValidToken(ethers.ZeroAddress)).to.be.true;
-        });
-
-        it("должен отклонять невалидные токены", async function () {
-            const fixture = await loadFixture(deployFullPlatformFixture);
-
-            // Добавляем невалидный токен в черный список
-            const invalidAddress = "0x1111111111111111111111111111111111111111";
-            await fixture.tokenValidator.setTokenBlacklist(invalidAddress, true, "Тестовый недействительный токен");
-
-            // Проверяем, что токен не валиден
-            expect(await fixture.tokenValidator.isValidToken(invalidAddress)).to.be.false;
-        });
-    });
+    console.log("✅ Тест расчета комиссий успешно завершен");
+  });
 });


### PR DESCRIPTION
## Summary
- bring back full helper implementations for contest tests
- restore original token lifecycle integration tests

## Testing
- `npm run test:e2e` *(fails: requires Hardhat installation)*

------
https://chatgpt.com/codex/tasks/task_e_684c9aeaf03c8323a33b4aa4f57afc06