### PR TITLE
Fix contest ID retrieval in helpers

### DIFF
--- a/test/helpers/ContestHelper.ts
+++ b/test/helpers/ContestHelper.ts
@@ -603,13 +603,15 @@ export async function createTestContest(
                 console.log(`Текущее значение lastId после создания конкурса: ${newLastId}`);
 
                 if (newLastId > initialLastId) {
-                    // Если lastId увеличился, используем его
-                    contestId = newLastId;
-                    console.log(`Используем lastId как contestId: ${contestId}`);
+                    // Если lastId увеличился, то идентификатор конкурса равен
+                    // предыдущему значению lastId (newLastId - 1)
+                    contestId = newLastId - BigInt(1);
+                    console.log(`Используем lastId-1 как contestId: ${contestId}`);
                 } else {
-                    // Если lastId не изменился, используем initialLastId + 1
-                    contestId = initialLastId + BigInt(1);
-                    console.log(`Используем initialLastId + 1 как contestId: ${contestId}`);
+                    // Если lastId не изменился, используем initialLastId как
+                    // наиболее вероятный идентификатор
+                    contestId = initialLastId;
+                    console.log(`Используем initialLastId как contestId: ${contestId}`);
                 }
             } catch (error) {
                 console.error(`Ошибка при получении lastId после создания: ${error}`);

--- a/test/integration/ContestTokens.test.ts
+++ b/test/integration/ContestTokens.test.ts
@@ -146,7 +146,7 @@ describe("Contest Token Integration Tests", function() {
     console.log(`Конкурс создан: ID=${contestId}, адрес эскроу=${escrowAddress}`);
 
     // Проверки
-    expect(contestId).to.be.gt(BigInt(0));
+    expect(contestId).to.be.gte(BigInt(0));
     expect(escrowAddress).to.not.equal(ethers.ZeroAddress);
 
     const escrowBalance = await mockUSDT.balanceOf(escrowAddress);
@@ -205,7 +205,13 @@ describe("Contest Token Integration Tests", function() {
       }
     );
 
-    expect(ethContestResult.contestId).to.be.gt(BigInt(0));
+    expect(ethContestResult.contestId).to.be.gte(BigInt(0));
+
+    // Контракт ContestFactory требует паузы минимум 1 час между созданиями
+    // конкурсов одним и тем же адресом. Продвигаем время, чтобы избежать
+    // отката с ошибкой "Wait between contests" при создании следующего
+    // конкурса в рамках этого теста.
+    await time.increase(3600 + 1);
 
     // USDC конкурс
     console.log("💵 Создание конкурса с USDC");
@@ -335,36 +341,16 @@ describe("Contest Token Integration Tests", function() {
         const receipt = await tx.wait();
         console.log(`✅ Транзакция подтверждена: ${receipt?.hash || 'нет хеша'}`);
 
-        // Получаем ID конкурса из событий
-        let contestId;
-        if (receipt && receipt.logs) {
-          for (const log of receipt.logs) {
-            try {
-              const parsed = contestFactory.interface.parseLog({
-                topics: log.topics,
-                data: log.data
-              });
-
-              if (parsed && parsed.name === "ContestCreated") {
-                contestId = parsed.args.contestId;
-                console.log(`✅ Конкурс создан: ID=${contestId}`);
-                break;
-              }
-            } catch (e) {
-              // Игнорируем ошибки парсинга
-            }
-          }
-        }
-
-        if (!contestId) {
-          console.log("⚠️ Не удалось получить ID из событий, пробуем lastId");
-          const lastId = await contestFactory.lastId();
-          contestId = lastId;
-          console.log(`Используем lastId как contestId: ${contestId}`);
-        }
+        // Определяем contestId по последнему значению lastId после выполнения
+        // транзакции. lastId увеличивается постфиксно, поэтому он указывает на
+        // следующий свободный идентификатор. ID только что созданного конкурса
+        // равен lastId - 1.
+        const lastIdAfter = await contestFactory.lastId();
+        let contestId = lastIdAfter - BigInt(1);
+        console.log(`Используем lastId-1 как contestId: ${contestId}`);
 
         // Теперь получаем эскроу контракт
-        const escrowAddress = await contestFactory.escrows(Number(contestId) - 1);
+        const escrowAddress = await contestFactory.escrows(Number(contestId));
         const escrow = await ethers.getContractAt("ContestEscrow", escrowAddress);
 
         usdcContestResult = {
@@ -406,7 +392,7 @@ describe("Contest Token Integration Tests", function() {
       throw error; // Пробрасываем ошибку дальше для провала теста
     }
 
-    expect(usdcContestResult.contestId).to.be.gt(BigInt(0));
+    expect(usdcContestResult.contestId).to.be.gte(BigInt(0));
     expect(usdcContestResult.contestId).to.be.gt(ethContestResult.contestId);
 
     console.log("✅ Тест с различными токенами успешно завершен");
@@ -446,7 +432,7 @@ describe("Contest Token Integration Tests", function() {
       }
     );
 
-    expect(contestResult.contestId).to.be.gt(BigInt(0));
+    expect(contestResult.contestId).to.be.gte(BigInt(0));
     console.log("✅ Тест валидации токенов успешно завершен");
   });
 
@@ -474,11 +460,16 @@ describe("Contest Token Integration Tests", function() {
           description: "Testing fee calculation with ETH"
         }
       }
-    );
+      );
 
-    // Проверяем комиссию ETH
-    const availableETHFees = await networkFeeManager.getAvailableETHFees();
-    expect(availableETHFees).to.equal(ethFee);
+      // Проверяем комиссию ETH
+      const availableETHFees = await networkFeeManager.getAvailableETHFees();
+      expect(availableETHFees).to.equal(ethFee);
+
+      // Между созданием конкурсов должна пройти как минимум 1 час. Увеличиваем
+      // время, чтобы следующая транзакция не была отклонена проверкой
+      // `Wait between contests` в контракте ContestFactory.
+      await time.increase(3600 + 1);
 
     // USDT конкурс
     const usdtTotalPrize = ethers.parseUnits("1000", await mockUSDT.decimals());


### PR DESCRIPTION
## Summary
- return `lastId - 1` from `createTestContest` when deriving IDs from the factory
- accept zero as a valid contest ID in integration tests

## Testing
- `npm ci --ignore-scripts`
- `npx hardhat test test/integration/ContestTokens.test.ts` *(fails: Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_684cc5dc73b88323b446e6e4bba0788b