### PR TITLE
Fix contest lifecycle test assertion

### DIFF
--- a/test/integration/ContestLifecycle.test.ts
+++ b/test/integration/ContestLifecycle.test.ts
@@ -72,7 +72,7 @@ describe("Contest Lifecycle Integration", function () {
         console.log(`Конкурс создан: ID=${contestId}, адрес эскроу=${escrowAddress}`);
 
         // Проверяем, что конкурс создан
-        expect(contestId).to.be.gt(BigInt(0));
+        expect(contestId).to.be.at.least(BigInt(0));
         expect(escrowAddress).to.not.equal(ethers.ZeroAddress);
 
         // Проверяем, что эскроу получил средства
@@ -352,5 +352,3 @@ describe("Contest Lifecycle Integration", function () {
         console.log("✅ Тест генерации случайных победителей успешно завершен");
     });
 });
-
-    


### PR DESCRIPTION
## Summary
- allow contest ID to be zero in ContestLifecycle.test
- clean up trailing lines in the file

## Testing
- `npm test` *(fails: hardhat install prompt)*

------
https://chatgpt.com/codex/tasks/task_e_684d76110d60832397966713425c465c