### PR TITLE
Fix double claim test to expect revert reason

### DIFF
--- a/test/unit/ContestEscrow.test.ts
+++ b/test/unit/ContestEscrow.test.ts
@@ -261,11 +261,12 @@ describe("ContestEscrow", function () {
                 .declareWinners([fixture.winner1.address], [1]);
 
             await escrow.connect(fixture.winner1).claimPrize();
-            
-            // Просто проверяем, что транзакция отменяется без уточнения причины
-            await expect(
-                escrow.connect(fixture.winner1).claimPrize()
-            ).to.be.reverted;
+
+            // Expect revert with specific reason on second claim attempt
+            await expectRevertWithReason(
+                escrow.connect(fixture.winner1).claimPrize(),
+                "Already claimed"
+            );
         });
 
         it("should reject claiming by non-winners", async function () {


### PR DESCRIPTION
## Summary
- ensure the double claim test checks for the 'Already claimed' revert reason

## Testing
- `npm run test:unit` *(fails: ENOENT: test runner couldn't execute)*

------
https://chatgpt.com/codex/tasks/task_e_684d9a609d8c83239ef65555185875bd